### PR TITLE
xlog: pointer slice

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,40 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,96 +1,72 @@
-linters:
-  # Disable all linters.
-  disable-all: true
-  # Enable specific linter
-  enable:
-    - sloglint
-    - errcheck
-    - gci
-    - wrapcheck
-
+version: "2"
 run:
-  # Number of operating system threads (`GOMAXPROCS`) that can execute golangci-lint simultaneously.
-  # If it is explicitly set to 0 (i.e. not the default) then golangci-lint will automatically set the value to match Linux container CPU quota.
-  # Default: the number of logical CPUs in the machine
   concurrency: 8
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 5m
-  go: '1.22.0'
-
+  go: 1.22.0
 output:
-  # Show statistics per linter.
-  show-stats: true
-  # Sort results by the order defined in `sort-order`.
-  sort-results: true
-  # Order to use when sorting results.
-  # Require `sort-results` to `true`.
-  # Possible values: `file`, `linter`, and `severity`.
-  #
-  # If the severity values are inside the following list, they are ordered in this order:
-  #   1. error
-  #   2. warning
-  #   3. high
-  #   4. medium
-  #   5. low
-  # Either they are sorted alphabetically.
   sort-order:
     - linter
     - file
     - severity
-
+linters:
+  default: none
+  enable:
+    - errcheck
+    - sloglint
+    - wrapcheck
+  settings:
+    errcheck:
+      exclude-functions:
+        - (net/http.ResponseWriter).Write
+    sloglint:
+      attr-only: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: '^//go:generate '
+    paths:
+      - .*\.gen\.go$
+      - .*\.ridl$
+      - vendor
+      - tools
+      - scripts
+      - bin
+      - .buildkite
+      - etc
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
-  # Default: 50
   max-issues-per-linter: 0
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
   max-same-issues: 0
-  exclude-rules:
-    - linters:
-        - lll
-      source: "^//go:generate "
-  exclude-dirs:
-    - "vendor"
-    - "tools"
-    - "scripts"
-    - "bin"
-    - ".buildkite"
-    - "etc"
-  exclude-files:
-    - ".*\\.gen\\.go$"
-    - ".*\\.ridl$"
-
-linters-settings:
-  sloglint:
-    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
-    attr-only: true
-  errcheck:
-    # List of functions to exclude from checking, where each entry is a single function to exclude.
-    # See https://github.com/kisielk/errcheck#excluding-functions for details.
-    exclude-functions:
-      - (net/http.ResponseWriter).Write
-
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/0xsequence/go-libs) # Custom section: groups all imports with the specified Prefix.
-    # Skip generated files.
-    # Default: true
-    skip-generated: true
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-    # Drops lexical ordering for custom sections.
-    # Default: false
-    no-lex-order: false
+formatters:
+  enable:
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/0xsequence/go-libs)
+      custom-order: true
+      no-lex-order: false
+  exclusions:
+    generated: lax
+    paths:
+      - .*\.gen\.go$
+      - .*\.ridl$
+      - vendor
+      - tools
+      - scripts
+      - bin
+      - .buildkite
+      - etc
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.4
 require (
 	github.com/0xsequence/ethkit v1.29.7
 	github.com/0xsequence/go-sequence v0.43.6
+	github.com/test-go/testify v1.1.4
 )
 
 require (
@@ -14,6 +15,7 @@ require (
 	github.com/consensys/bavard v0.1.22 // indirect
 	github.com/consensys/gnark-crypto v0.14.0 // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/ethereum/c-kzg-4844/bindings/go v0.0.0-20230126171313-363c7d7593b4 // indirect
@@ -24,6 +26,7 @@ require (
 	github.com/goware/superr v0.0.2 // indirect
 	github.com/holiman/uint256 v1.3.1 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/supranational/blst v0.3.13 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
 github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=

--- a/xlog/xlog.go
+++ b/xlog/xlog.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/0xsequence/go-sequence/lib/prototyp"
 
@@ -118,4 +119,25 @@ func ProjectID(projectID uint64) slog.Attr {
 
 func Stringer[T fmt.Stringer](k string, v T) slog.Attr {
 	return slog.String(k, v.String())
+}
+
+func PointerSlice[T any](key string, slice []*T) slog.Attr {
+	var b strings.Builder
+	b.WriteString("[")
+
+	for i, item := range slice {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+
+		if item == nil {
+			b.WriteString("<nil>")
+		} else {
+			b.WriteString(fmt.Sprintf("&%+v", *item))
+		}
+	}
+
+	b.WriteString("]")
+
+	return slog.String(key, b.String())
 }

--- a/xlog/xlog_test.go
+++ b/xlog/xlog_test.go
@@ -1,0 +1,199 @@
+package xlog_test
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/0xsequence/go-sequence/lib/prototyp"
+	"github.com/test-go/testify/assert"
+
+	"github.com/0xsequence/go-libs/networks"
+	"github.com/0xsequence/go-libs/xlog"
+)
+
+func TestError(t *testing.T) {
+	err := errors.New("sample error")
+	attr := xlog.Error(err)
+
+	assert.Equal(t, "error", attr.Key)
+	assert.Equal(t, err, attr.Value.Any())
+}
+
+func TestErrorf(t *testing.T) {
+	format := "formatted error %s"
+	args := []any{"test"}
+	attr := xlog.Errorf(format, args...)
+
+	assert.Equal(t, "error", attr.Key)
+	assert.Equal(t, fmt.Sprintf(format, args...), attr.Value.String())
+}
+
+func TestID(t *testing.T) {
+	id := uint64(12345)
+	attr := xlog.ID(id)
+
+	assert.Equal(t, "id", attr.Key)
+	assert.Equal(t, id, attr.Value.Uint64())
+}
+
+func TestChainID(t *testing.T) {
+	chainID := uint64(67890)
+	attr := xlog.ChainID(chainID)
+
+	assert.Equal(t, "chainId", attr.Key)
+	assert.Equal(t, chainID, attr.Value.Uint64())
+}
+
+func TestChainIDString(t *testing.T) {
+	chainID := "12345"
+	attr := xlog.ChainIDString(chainID)
+
+	assert.Equal(t, "chainId", attr.Key)
+	expectedID, _ := strconv.ParseUint(chainID, 10, 64)
+	assert.Equal(t, expectedID, attr.Value.Uint64())
+}
+
+func TestChainNetworkName(t *testing.T) {
+	name := "NetworkName"
+	attr := xlog.ChainNetworkName(name)
+
+	assert.Equal(t, "name", attr.Key)
+	assert.Equal(t, name, attr.Value.String())
+}
+
+func TestChainIDNetwork(t *testing.T) {
+	network := &networks.Network{
+		ChainID: 12345,
+		Name:    "NetworkName",
+	}
+	attr := xlog.ChainIDNetwork(network)
+
+	assert.Equal(t, "network", attr.Key)
+	// assert individual fields (this is a bit dependent on how you handle logging with slog)
+}
+
+func TestContractAddress(t *testing.T) {
+	address := prototyp.Hash("sampleAddress")
+	attr := xlog.ContractAddress(address)
+
+	assert.Equal(t, "contractAddress", attr.Key)
+	assert.Equal(t, address.String(), attr.Value.String())
+}
+
+func TestCollectionAddress(t *testing.T) {
+	address := prototyp.Hash("sampleCollectionAddress")
+	attr := xlog.CollectionAddress(address)
+
+	assert.Equal(t, "collectionAddress", attr.Key)
+	assert.Equal(t, address.String(), attr.Value.String())
+}
+
+func TestCurrencyAddress(t *testing.T) {
+	address := prototyp.Hash("sampleCurrencyAddress")
+	attr := xlog.CurrencyAddress(address)
+
+	assert.Equal(t, "currencyAddress", attr.Key)
+	assert.Equal(t, address.String(), attr.Value.String())
+}
+
+func TestOrderID(t *testing.T) {
+	orderID := "sampleOrderID"
+	attr := xlog.OrderID(orderID)
+
+	assert.Equal(t, "orderID", attr.Key)
+	assert.Equal(t, orderID, attr.Value.String())
+}
+
+func TestTokenIDString(t *testing.T) {
+	tokenID := "sampleTokenID"
+	attr := xlog.TokenIDString(tokenID)
+
+	assert.Equal(t, "tokenId", attr.Key)
+	assert.Equal(t, tokenID, attr.Value.String())
+}
+
+func TestTokenID(t *testing.T) {
+	tokenID := prototyp.NewBigIntFromDecimalString("1234567890")
+	attr := xlog.TokenID(tokenID)
+
+	assert.Equal(t, "tokenId", attr.Key)
+	assert.Equal(t, tokenID.String(), attr.Value.String())
+}
+
+func TestTokenIDPtr(t *testing.T) {
+	tokenID := prototyp.NewBigIntFromDecimalString("1234567890")
+	attr := xlog.TokenIDPtr(&tokenID)
+
+	assert.Equal(t, "tokenId", attr.Key)
+	assert.Equal(t, tokenID.String(), attr.Value.String())
+
+	// Test with nil pointer
+	var nilTokenID *prototyp.BigInt
+	attrNil := xlog.TokenIDPtr(nilTokenID)
+
+	assert.Equal(t, "tokenId", attrNil.Key)
+	assert.Equal(t, "empty", attrNil.Value.String())
+}
+
+func TestTokenIDBigInt(t *testing.T) {
+	tokenID := big.NewInt(1234567890)
+	attr := xlog.TokenIDBigInt(*tokenID)
+
+	assert.Equal(t, "tokenId", attr.Key)
+	assert.Equal(t, tokenID.String(), attr.Value.String())
+}
+
+func TestEntity(t *testing.T) {
+	entity := "sampleEntity"
+	attr := xlog.Entity(entity)
+
+	assert.Equal(t, "entity", attr.Key)
+	assert.Equal(t, entity, attr.Value.String())
+}
+
+func TestSource(t *testing.T) {
+	source := "sampleSource"
+	attr := xlog.Source(source)
+
+	assert.Equal(t, "source", attr.Key)
+	assert.Equal(t, source, attr.Value.String())
+}
+
+func TestProjectID(t *testing.T) {
+	projectID := uint64(100)
+	attr := xlog.ProjectID(projectID)
+
+	assert.Equal(t, "projectId", attr.Key)
+	assert.Equal(t, projectID, attr.Value.Uint64())
+}
+
+type sampleStringer struct{}
+
+func (s sampleStringer) String() string { return "sampleString" }
+
+func TestStringer(t *testing.T) {
+	str := sampleStringer{}
+	attr := xlog.Stringer("sampleKey", str)
+
+	assert.Equal(t, "sampleKey", attr.Key)
+	assert.Equal(t, "sampleString", attr.Value.String())
+}
+
+func TestPointerSlice(t *testing.T) {
+	type sampleType struct {
+		ID int
+	}
+	slice := []*sampleType{
+		{ID: 1},
+		nil,
+		{ID: 2},
+	}
+	attr := xlog.PointerSlice("sampleSlice", slice)
+
+	expected := "[&{ID:1} <nil> &{ID:2}]"
+	assert.Equal(t, "sampleSlice", attr.Key)
+	assert.Equal(t, expected, attr.Value.String())
+}


### PR DESCRIPTION
Added `PointerSlice` function, for easier debugging.

```go
func TestPointerSlice(t *testing.T) {
	type sampleType struct {
		ID int
	}
	slice := []*sampleType{
		{ID: 1},
		nil,
		{ID: 2},
	}

	attr := xlog.PointerSlice("sampleSlice", slice) // sampleSlice=[&{ID:1} <nil> &{ID:2}]
}
```

Tests for `xlog`.
Github workflow for tests and linter.
Updated golangci-lint.

