### PR TITLE
Endpoint logger

### DIFF
--- a/endpointlogger/context.go
+++ b/endpointlogger/context.go
@@ -1,0 +1,26 @@
+package endpointlogger
+
+import (
+	"context"
+	"time"
+)
+
+type ctxKey struct{}
+
+type ctxVal struct {
+	service  string
+	endpoint string
+	time     time.Time
+}
+
+func setValues(ctx context.Context, service, endpoint string, t time.Time) context.Context {
+	return context.WithValue(ctx, ctxKey{}, ctxVal{service: service, endpoint: endpoint, time: t})
+}
+
+func getValues(ctx context.Context) (ctxVal, bool) {
+	if v, ok := ctx.Value(ctxKey{}).(ctxVal); ok {
+		return v, ok
+	}
+
+	return ctxVal{}, false
+}

--- a/endpointlogger/logger.go
+++ b/endpointlogger/logger.go
@@ -1,0 +1,43 @@
+package endpointlogger
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// LogHandler creates a new slog handler that will add "service", "endpoint" and "since" attributes to logs
+func LogHandler(handler slog.Handler) slog.Handler {
+	return &endpointHandler{
+		handler: handler,
+	}
+}
+
+type endpointHandler struct {
+	handler slog.Handler
+}
+
+func (h *endpointHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *endpointHandler) Handle(ctx context.Context, record slog.Record) error {
+	values, ok := getValues(ctx)
+	if ok {
+		record.AddAttrs(
+			slog.String("service", values.service),
+			slog.String("endpoint", values.endpoint),
+			slog.Duration("since", time.Since(values.time)),
+		)
+	}
+
+	return h.handler.Handle(ctx, record) //nolint
+}
+
+func (h *endpointHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &endpointHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+func (h *endpointHandler) WithGroup(name string) slog.Handler {
+	return &endpointHandler{handler: h.handler.WithGroup(name)}
+}

--- a/endpointlogger/logger.go
+++ b/endpointlogger/logger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Deprecated: LogHandler is experimental and might be removed in near future. Use with caution.
 // LogHandler creates a new slog handler that will add "service", "endpoint" and "since" attributes to logs
 func LogHandler(handler slog.Handler) slog.Handler {
 	return &endpointHandler{

--- a/endpointlogger/middleware.go
+++ b/endpointlogger/middleware.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Middleware parse webrcp "service" "name" and endpoint name and adds it to context,
+// Middleware captures webrpc service and endpoint name to a context
 // also adds "since" so logs will have attribute when the log happened since received request to server
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/endpointlogger/middleware.go
+++ b/endpointlogger/middleware.go
@@ -1,0 +1,35 @@
+package endpointlogger
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Middleware parse webrcp "service" "name" and endpoint name and adds it to context,
+// also adds "since" so logs will have attribute when the log happened since received request to server
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		i := strings.LastIndex(path, "/")
+		var endpoint, service string
+		if i > 0 {
+			endpoint = path[i+1:]
+
+			// look for segment before last
+			j := strings.LastIndex(path[:i], "/")
+			if j == -1 {
+				service = path[:i]
+			} else {
+				service = path[j+1 : i]
+			}
+		}
+
+		if endpoint != "" && service != "" {
+			r = r.WithContext(setValues(r.Context(), service, endpoint, time.Now().UTC()))
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/endpointlogger/middleware.go
+++ b/endpointlogger/middleware.go
@@ -12,22 +12,18 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		i := strings.LastIndex(path, "/")
 		var endpoint, service string
-		if i > 0 {
-			endpoint = path[i+1:]
-
-			// look for segment before last
-			j := strings.LastIndex(path[:i], "/")
-			if j == -1 {
-				service = path[:i]
-			} else {
-				service = path[j+1 : i]
+		parts := strings.Split(path, "/")
+		if len(parts) > 3 {
+			// check if the path is in webrpc format, and if so, then extract the service and endpoint
+			if parts[len(parts)-3] == "rpc" {
+				service = parts[len(parts)-2]
+				endpoint = parts[len(parts)-1]
 			}
-		}
 
-		if endpoint != "" && service != "" {
-			r = r.WithContext(setValues(r.Context(), service, endpoint, time.Now().UTC()))
+			if endpoint != "" && service != "" {
+				r = r.WithContext(setValues(r.Context(), service, endpoint, time.Now().UTC()))
+			}
 		}
 
 		next.ServeHTTP(w, r)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/traceid"
 	"github.com/golang-cz/devslog"
 
+	"github.com/0xsequence/go-libs/endpointlogger"
 	"github.com/0xsequence/go-libs/httpdebug"
 )
 
@@ -67,6 +68,9 @@ func New(o *Options) *slog.Logger {
 
 	// add traceid handler
 	slogHandler = traceid.LogHandler(slogHandler)
+
+	// add endpoint logger handler
+	slogHandler = endpointlogger.LogHandler(slogHandler)
 
 	if o.HTTPDebug != nil && o.HTTPDebug.Key != "" && o.HTTPDebug.Value != "" {
 		slogHandler = httpdebug.LogHandler(*o.HTTPDebug)(slogHandler)


### PR DESCRIPTION
This PR adds endpoint logger, which would add `endpoint name`, `service name` and `time` when the request was received.

Then whenever we would do log from application, we would also get these attributes in log, for better debugging and tracking. It would also add these attributes to logs outside of the handler, for example to logs from database functions, etc.

```go
slog.String("service", values.service)
slog.String("endpoint", values.endpoint)
slog.Duration("since", time.Since(values.time))
```